### PR TITLE
Include scipy in setup dependency list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ AUTHOR = 'Josh Montague'
 REQUIRED = [
     'pandas',
     'numpy',
+    'scipy',
     'statsmodels',
     'matplotlib',
 ]


### PR DESCRIPTION
When installing from pip+github, the statsmodels dependency on scipy doesn't seem to properly install scipy. So, adding scipy to the setup file for stldecompose just to be sure that it gets installed.